### PR TITLE
Automated CASE Validation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,14 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m venv development
@@ -33,12 +35,22 @@ jobs:
         python -m pip install flake8 pylint pytest rdflib
         python setup.py install
         pillow2case --help
+  
     - name: Lint with flake8
       run: |
         . development/bin/activate
         flake8  --count --select=E9,F63,F7,F82 --show-source --statistics */*.py *.py
         flake8  --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics */*.py *.py
+
     - name: Lint with pylint
       run: |
         . development/bin/activate
         pylint --exit-zero *.py */*.py
+
+    # Run the CASE validation job to confirm all examples in pillow_output_examples are valid
+    - name: CASE Export Validation
+      uses: kchason/case-validation-action@v2.5
+      with:
+        case-path: ./pillow_output_examples/
+        case-version: "case-1.1.0"
+        extension-filter: "json"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CASE-Implementation-PyPI-Pillow](https://github.com/casework/CASE-Implementation-PyPI-Pillow/actions/workflows/python-package.yml/badge.svg)](https://github.com/casework/CASE-Implementation-PyPI-Pillow/actions/workflows/python-package.yml)
-
+![CASE Version](https://img.shields.io/badge/CASE%20Version-1.1.0-brightgreen)
 
 # CASE-Implementation-Pillow
 A repository for the development of a [Pillow](https://pypi.org/project/Pillow/) to [CASE](https://caseontology.org) implementation.


### PR DESCRIPTION
- Switch to NodeJS 16 actions to avoid deprecated NodeJS 12 based actions
- Add CASE Validation Action to validate `.json` files in `pillow_output_examples`
- Add Python 3.10 and 3.11 to the matrix for testing
- CASE version badge on README