### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     Pillow
     rdflib
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 scripts =
     pillow_case/exif_node_maker.py
 


### PR DESCRIPTION
The Python 3.7 End of Support is coming 2023-06-27, and various upstream tools, including from this project's perspective `case-utils`, have consequently dropped support for that Python version.

References:
* https://github.com/casework/CASE-Utilities-Python/pull/99
* https://www.python.org/downloads/